### PR TITLE
Fixes problem with compiling with Boost >= 1.67 - CPPT-22 + Pandas FutureWarning - CPPT-7

### DIFF
--- a/CppTransport/translator/backends/shared/fundamental.cpp
+++ b/CppTransport/translator/backends/shared/fundamental.cpp
@@ -27,17 +27,17 @@
 #include <functional>
 #include <time.h>
 
-#include "fundamental.h"
-#include "to_printable.h"
-#include "translation_unit.h"
-#include "formatter.h"
-#include "core.h"
-
 #include "boost/lexical_cast.hpp"
 #include "boost/uuid/uuid.hpp"
 #include "boost/uuid/string_generator.hpp"
 #include "boost/uuid/uuid_io.hpp"
 #include "boost/date_time/posix_time/posix_time.hpp"
+
+#include "fundamental.h"
+#include "to_printable.h"
+#include "translation_unit.h"
+#include "formatter.h"
+#include "core.h"
 
 #include "openssl/md5.h"
 

--- a/CppTransport/transport-runtime/utilities/plot_environment.h
+++ b/CppTransport/transport-runtime/utilities/plot_environment.h
@@ -156,6 +156,8 @@ namespace transport
               {
                 if(env.has_seaborn())
                   {
+                    outf << "from pandas.plotting import register_matplotlib_converters" << '\n';
+                    outf << "register_matplotlib_converters()" << '\n';
                     outf << "import seaborn as sns" << '\n';
                     outf << "sns.set()" << '\n';
                   }


### PR DESCRIPTION
This fixes a problem where the function `likely` was being defined by both Boost and GINAC, and so threw errors while building CppTransport.
By changing the ordering of the include statements, this function clash has been avoided, and so CppTransport should successfully build with the latest versions of Boost.
This commit is on *my* branch 201901-ds283 to avoid having to pull in all my other changes to the task scheduler, and hence this is a repeat commit.