### PR TITLE
Improve spectral index reporting

### DIFF
--- a/CppTransport/templates/cosmosis_getdist_latex_template.txt
+++ b/CppTransport/templates/cosmosis_getdist_latex_template.txt
@@ -4,8 +4,8 @@ KPIV* k_{piv}
 NPIV* N_{piv}
 A_S* \ln(10^{10} A_s)
 A_T* \ln(10^{10} A_t)
-N_S* n_s
-N_T* n_t
+N_S_FULL* n_{s}^{full}
+N_T_FULL* n_{t}^{full}
 R* r
 NEFOLD* N
 B_EQUI* B^{eq}

--- a/CppTransport/templates/cosmosis_getdist_python_template.py
+++ b/CppTransport/templates/cosmosis_getdist_python_template.py
@@ -87,7 +87,7 @@ results["POST"] = -1.0*results["POST"]
 
 
 # Selecting only the output columns that we want to write
-OutputColumns = ['weights', 'POST', $FOR{ £PRIOR, "£QUOTE£PRIOR£QUOTE.upper()£COMMA ", PriorNames, False, True}, 'K_PIV', 'N_PIV', 'A_S', 'A_T', 'N_S', 'N_T', 'R', 'NEFOLD', 'B_EQUI', 'FNL_EQUI', 'B_SQU', 'FNL_SQU', 'B_FOLD', 'FNL_FOLD']
+OutputColumns = ['weights', 'POST', $FOR{ £PRIOR, "£QUOTE£PRIOR£QUOTE.upper()£COMMA ", PriorNames, False, True}, 'K_PIV', 'N_PIV', 'A_S', 'A_T', 'N_S', 'N_S_FULL', 'N_T', 'N_T_FULL', 'R', 'NEFOLD', 'B_EQUI', 'FNL_EQUI', 'B_SQU', 'FNL_SQU', 'B_FOLD', 'FNL_FOLD']
 results = results[OutputColumns]
 results.to_csv(str(string_out_folder) + str(string_out) + '.txt', header = None, index = None, sep = " ")
 # Write the output to a text file using pandas
@@ -122,7 +122,7 @@ params = []
 
 $FOR{ £PRIOR, "params.append(£QUOTE£PRIOR£QUOTE)", PriorNames, True, False}
 
-params.extend(['A_S', 'A_T', 'N_S', 'N_T', 'R', 'NEFOLD'])
+params.extend(['A_S', 'A_T', 'N_S_FULL', 'N_T_FULL', 'R'])
 
 # Now need to see if we have any fNL values, and if so then we want to add them to the triangle plot too
 if Data['FNL_EQUI'].all():

--- a/CppTransport/templates/cosmosis_mcmc_template.ini
+++ b/CppTransport/templates/cosmosis_mcmc_template.ini
@@ -30,7 +30,7 @@ modules = cppt_sample consistency modified_class planck
 values = $FILENAME_mcmc/$MODEL_values.ini
 priors = $FILENAME_mcmc/$MODEL_priors.ini
 
-extra_output = twopf_observables/k_piv twopf_observables/N_piv twopf_observables/A_s twopf_observables/A_t twopf_observables/n_s twopf_observables/n_t twopf_observables/r thrpf_observables/B_equi thrpf_observables/fNL_equi thrpf_observables/B_squ thrpf_observables/fNL_squ thrpf_observables/B_fold thrpf_observables/fNL_fold wavenumber_spectrum/spec_table failed_samples/no_end_inflation failed_samples/negative_Hsq failed_samples/integrate_nan failed_samples/zero_massless_time failed_samples/negative_epsilon failed_samples/eps_geq_three failed_samples/negative_pot failed_samples/noFind_hor_exit failed_samples/ICs_before_start failed_samples/leq_60_efolds failed_samples/varying_Spec $FOR{ £FIELDNUM, "twopf_observables/NormMassMatrixEigenValue£FIELDNUM ", NumFields , False, False} twopf_observables/Nefold twopf_observables/CppTTime
+extra_output = twopf_observables/k_piv twopf_observables/N_piv twopf_observables/A_s twopf_observables/A_t twopf_observables/n_s twopf_observables/n_t twopf_observables/n_s_full twopf_observables/n_t_full twopf_observables/r thrpf_observables/B_equi thrpf_observables/fNL_equi thrpf_observables/B_squ thrpf_observables/fNL_squ thrpf_observables/B_fold thrpf_observables/fNL_fold $FOR{ £FIELDNUM, "twopf_observables/NormMassMatrixEigenValue£FIELDNUM ", NumFields , False, False} twopf_observables/Nefold twopf_observables/CppTTime
 
 likelihoods = planck2015
 quiet=F


### PR DESCRIPTION
- Firstly, this fixes a bug where we weren't reporting enough accuracy in the power spectrum to Class. Instead of using nine significant figures, we now use the maximum precision of a C++ double (which should be ~16).

- Secondly, we now report the value of ns^full, and this is the principal value used for the spectral index when using our GetDist analysis scripts.